### PR TITLE
fix(deal): Use correct namespaces for some deal classes

### DIFF
--- a/src/Resources/Deal/GetDeal.php
+++ b/src/Resources/Deal/GetDeal.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace JobVerplanke\LaravelActiveCampaign\Resources\Contact;
+namespace JobVerplanke\LaravelActiveCampaign\Resources\Deal;
 
 use JobVerplanke\LaravelActiveCampaign\Get;
 use Illuminate\Http\Client\Response;

--- a/src/Resources/Deal/GetDeals.php
+++ b/src/Resources/Deal/GetDeals.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace JobVerplanke\LaravelActiveCampaign\Resources\Contact;
+namespace JobVerplanke\LaravelActiveCampaign\Resources\Deal;
 
 use JobVerplanke\LaravelActiveCampaign\Get;
 use Illuminate\Http\Client\Response;


### PR DESCRIPTION
To avoid:

```
Class JobVerplanke\LaravelActiveCampaign\Resources\Contact\GetDeal located in ./vendor/jobverplanke/laravel-active-campaign/src/Resources/Deal/GetDeal.php does not comply with psr-4 autoloading standard. Skipping.
Class JobVerplanke\LaravelActiveCampaign\Resources\Contact\GetDeals located in ./vendor/jobverplanke/laravel-active-campaign/src/Resources/Deal/GetDeals.php does not comply with psr-4 autoloading standard. Skipping.
```